### PR TITLE
main: Autodetect project if one is not specified

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -142,8 +142,7 @@ func main() {
 		}
 	}
 
-	valid, err := flagsAreValid()
-	if !valid {
+	if err := validateFlags(); err != nil {
 		logger.Fatalf("invalid flags: %v", err)
 	}
 
@@ -264,10 +263,8 @@ func determineProjectID() (string, error) {
 
 	// Try to get project ID by retrieving default value in gcloud.
 	cmd := exec.Command("gcloud", "config", "get-value", "core/project", "-q")
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
 	err := cmd.Run()
 	if err != nil {
 		msg := "error when running gcloud command to get default project"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/cloud-run-release-operator
 go 1.14
 
 require (
-	cloud.google.com/go v0.60.0 // indirect
+	cloud.google.com/go v0.60.0
 	github.com/TV4/logrus-stackdriver-formatter v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/jonboulle/clockwork v0.2.0


### PR DESCRIPTION
This uses the compute metadata package to detect the ID of the project on which the service is deployed. If the tool is not being run on GCE, it tries to detect the project ID by executing a `gcloud` command to get the default project