### PR TITLE
Update instructions on permissions for the manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,16 @@ To set up this on Cloud Run, run the following steps on your shell:
         --display-name "Cloud Run Release Manager"
     ```
 
-    And give it permissions to manage your services on the Cloud Run API:
+    And give it permissions to manage your services on the Cloud Run API, to use
+    other service accounts as their identity when updating Cloud Run services,
+    and to access metrics on your services.
 
-    ```
+    ```sh
     gcloud projects add-iam-policy-binding $PROJECT_ID \
         --member=serviceAccount:release-manager@${PROJECT_ID}.iam.gserviceaccount.com \
-        --role=roles/run.admin
+        --role=roles/run.admin \
+        --role=roles/iam.serviceAccountUser \
+        --role=roles/monitoring.viewer
     ```
 
 1. (Optional) Mirror the docker image to your GCP project.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To set up this on Cloud Run, run the following steps on your shell:
 
     And give it permissions to manage your services on the Cloud Run API, to use
     other service accounts as their identity when updating Cloud Run services,
-    and to access metrics on your services.
+    and to access metrics on your services:
 
     ```sh
     gcloud projects add-iam-policy-binding $PROJECT_ID \


### PR DESCRIPTION
This adds two roles in the instructions when deploying the Release Manager. The first allows to use other service accounts during updates. The second gives access to metrics to the Release Manager.