### PR TITLE
Add label instructions local set-up section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ to **v1**
 
 ## Try it out (locally)
 
-1. Configure your service(s) to be selected for gradual rollouts by adding the
-   `rollout-strategy=gradual` label to your service(s):
+1. [Label the Cloud Run
+   services](https://cloud.google.com/run/docs/configuring/labels) (with label
+   `rollout-strategy=gradual`) for them to be selected for gradual rollouts:
 
     ```sh
     gcloud run services update <YOUR_SERVICE> \
@@ -117,27 +118,27 @@ the label `rollout-strategy=gradual` every minute by looking at the candidate's
 metrics for the past 30 minutes by default.
 
 The health is determined using the metrics and configured health criteria. If
-metrics show a healthy candidate, traffic to candidate is increased. But if
-metrics show an unhealthy candidate, a roll back is performed.
+metrics show a healthy candidate, traffic to the candidate revision is
+increased. But if metrics show an unhealthy candidate, a roll back is performed.
 
 ### Default rollout configuration
 
 When running the Release Manager, default configuration values are used. The
 most relevant values are:
 
-* `-healthcheck-offset=30m`: When assessing the candidate's health, the Release
+- `-healthcheck-offset=30m`: When assessing the candidate's health, the Release
   Manager will get metrics about the candidate revision from the last 30
   minutes
-* `-min-requests=100`: The Release Manager expects `100` requests in the past 30
+- `-min-requests=100`: The Release Manager expects `100` requests in the past 30
   minutes (given by `healthcheck-offset`). If no enough requests were made in
   that interval, no rollout or rollback is performed even if the other metrics
   show a healthy/unhealthy candidate
-* `-max-error-rate=1`: By default, the only health criteria is a expected max
+- `-max-error-rate=1`: By default, the only health criteria is a expected max
   server error rate of 1%
-* `-min-wait=30m`: If the candidate revision got the minimum number of requests
-  and was healthy, it can only be rolled out further only if 30 minutes since
-  last roll out has elapsed. If the candidate was unhealthy, however, it is
-  rolled back independent of the elapsed time since last rollout.
+- `-min-wait=30m`: If the candidate revision got the minimum number of requests
+  and was healthy, it can be rolled out further only if 30 minutes since last
+  roll out has elapsed. If the candidate was unhealthy, however, it is rolled
+  back independent of the elapsed time since last rollout.
 
 The configuration values can be changed as described in the
 [configuration section](#configuration).

--- a/README.md
+++ b/README.md
@@ -116,14 +116,31 @@ Once you run this command, it will check the health of Cloud Run services with
 the label `rollout-strategy=gradual` every minute by looking at the candidate's
 metrics for the past 30 minutes by default.
 
-* The health is determined using the metrics and configured health criteria
-* The Release Manager expects `100` requests in the past 30 minutes before
-  assessing the candidate's health. If no enough requests were made, no rollout
-  or rollback is performed
-* By default, the only health criteria is a expected max server error rate of
-1%
-* If metrics show a healthy candidate, traffic to candidate is increased
-* If metrics show an unhealthy candidate, a roll back is performed.
+The health is determined using the metrics and configured health criteria. If
+metrics show a healthy candidate, traffic to candidate is increased. But if
+metrics show an unhealthy candidate, a roll back is performed.
+
+### Default rollout configuration
+
+When running the Release Manager, default configuration values are used. The
+most relevant values are:
+
+* `-healthcheck-offset=30m`: When assessing the candidate's health, the Release
+  Manager will get metrics about the candidate revision from the last 30
+  minutes
+* `-min-requests=100`: The Release Manager expects `100` requests in the past 30
+  minutes (given by `healthcheck-offset`). If no enough requests were made in
+  that interval, no rollout or rollback is performed even if the other metrics
+  show a healthy/unhealthy candidate
+* `-max-error-rate=1`: By default, the only health criteria is a expected max
+  server error rate of 1%
+* `-min-wait=30m`: If the candidate revision got the minimum number of requests
+  and was healthy, it can only be rolled out further only if 30 minutes since
+  last roll out has elapsed. If the candidate was unhealthy, however, it is
+  rolled back independent of the elapsed time since last rollout.
+
+The configuration values can be changed as described in the
+[configuration section](#configuration).
 
 ## Setup on GCP
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,16 @@ to **v1**
 
 ## Try it out (locally)
 
-1. Check out this repository.
+1. Configure your service(s) to be selected for gradual rollouts by adding the
+   `rollout-strategy=gradual` label to your service(s):
+
+    ```sh
+    gcloud run services update <YOUR_SERVICE> \
+    --labels rollout-strategy=gradual \
+    --region us-east1
+    ```
+
+1. Clone this repository.
 1. Make sure you have Go compiler installed, run:
 
     ```sh
@@ -99,7 +108,7 @@ to **v1**
 
 1. To start the program, run:
 
-    ```shell
+    ```sh
     ./cloud_run_release_manager -cli -project=<YOUR_PROJECT>
     ```
 
@@ -107,11 +116,14 @@ Once you run this command, it will check the health of Cloud Run services with
 the label `rollout-strategy=gradual` every minute by looking at the candidate's
 metrics for the past 30 minutes by default.
 
-- The health is determined using the metrics and configured health criteria
-- By default, the only health criteria is a expected max server error rate of
+* The health is determined using the metrics and configured health criteria
+* The Release Manager expects `100` requests in the past 30 minutes before
+  assessing the candidate's health. If no enough requests were made, no rollout
+  or rollback is performed
+* By default, the only health criteria is a expected max server error rate of
 1%
-- If metrics show a healthy candidate, traffic to candidate is increased
-- If metrics show an unhealthy candidate, a roll back is performed.
+* If metrics show a healthy candidate, traffic to candidate is increased
+* If metrics show an unhealthy candidate, a roll back is performed.
 
 ## Setup on GCP
 


### PR DESCRIPTION
This adds instructions of how to add labels to a service. It also clarifies the number of requests needed to evaluate the candidate's health