### PR TITLE
Mention the required label selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,15 @@ one.
 ## How does it work?
 
 Cloud Run Release Manager periodically checks for new revisions in the services
-that opted-in for gradual rollouts. To opt-in services for gradual rollouts, a
-label must be assigned to them. If a new revision with no traffic is found in
-these services, the Release Manager automatically assigns some initial traffic
-to the new revision. This new revision is tagged `candidate` while the previous
-revision serving traffic is tagged `stable`.
+that opted-in for gradual rollouts.
+
+To opt-in services for gradual rollouts, a label must be assigned to them. If a
+new revision with no traffic is found in these services, the Release Manager
+automatically assigns some initial traffic to the new revision.
+
+The Release Manager manages 2 revisions at a time: the last revision that
+reached 100% of the traffic which is tagged `stable` and the newest deployment
+which is tagged `candidate`.
 
 Depending on the candidate's health, traffic to the `candidate` is increased or
 traffic to the candidate is dropped and is redirected to the `stable` revision.

--- a/README.md
+++ b/README.md
@@ -42,16 +42,18 @@ one.
 Cloud Run Release Manager periodically checks for new revisions in the services
 that opted-in for gradual rollouts.
 
-To opt-in services for gradual rollouts, a label must be assigned to them. If a
-new revision with no traffic is found in these services, the Release Manager
-automatically assigns some initial traffic to the new revision.
+To opt-in services for gradual rollouts, you should label your services with
+`rollout-strategy=gradual` (default value). If a service has a newly deployed
+revision with 0% traffic, the Release Manager automatically assigns some initial
+traffic to the new revision (5% by default).
 
 The Release Manager manages 2 revisions at a time: the last revision that
-reached 100% of the traffic which is tagged `stable` and the newest deployment
-which is tagged `candidate`.
+reached 100% of the traffic (tagged as `stable`) and the newest deployment
+(tagged as `candidate`).
 
-Depending on the candidate's health, traffic to the `candidate` is increased or
-traffic to the candidate is dropped and is redirected to the `stable` revision.
+Depending on the candidate revision’s health and other configurable factors
+(such as served request count or time elapsed), this revision is either
+gradually rolled out to a higher percentage of traffic, or entirely rolled back.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ one.
     + [Scenario 1: Automated Rollouts](#scenario-1-automated-rollouts)
     + [Scenario 2: Automated Rollbacks](#scenario-2-automated-rollbacks)
 - [Try it out (locally)](#try-it-out-locally)
-- [Setup](#setup)
+- [Setup on GCP](#setup-on-gcp)
 - [Configuration](#configuration)
   * [Choosing services](#choosing-services)
   * [Rollout strategy](#rollout-strategy)
@@ -40,13 +40,14 @@ one.
 ## How does it work?
 
 Cloud Run Release Manager periodically checks for new revisions in the services
-that opted-in for gradual rollouts. If a new revision with no traffic is found,
-the Release Manager automatically assigns it some initial traffic. This new
-revision is labeled `candidate` while the previous revision serving traffic is
-labeled `stable`.
+that opted-in for gradual rollouts. To opt-in services for gradual rollouts, a
+label must be assigned to them. If a new revision with no traffic is found in
+these services, the Release Manager automatically assigns some initial traffic
+to the new revision. This new revision is tagged `candidate` while the previous
+revision serving traffic is tagged `stable`.
 
-Depending on the candidate's health, traffic to the `candidate` is increased
-or traffic to the candidate is dropped and is redirected to the `stable` revision.
+Depending on the candidate's health, traffic to the `candidate` is increased or
+traffic to the candidate is dropped and is redirected to the `stable` revision.
 
 ### Examples
 
@@ -106,13 +107,14 @@ metrics for the past 30 minutes by default.
 - If metrics show a healthy candidate, traffic to candidate is increased
 - If metrics show an unhealthy candidate, a roll back is performed.
 
-## Setup
+## Setup on GCP
 
-Cloud Run Release Manager is distributed as a server deployed to
-Cloud Run, invoked periodically by [Cloud
+Cloud Run Release Manager is distributed as a service deployed to Cloud Run on
+your own project, invoked periodically by [Cloud
 Scheduler](https://cloud.google.com/scheduler/).
 
-To set up this on Cloud Run, run the following steps on your shell:
+To set up the Release Manager on Cloud Run, run the following steps on your
+shell:
 
 1. Set your project ID in a variable:
 


### PR DESCRIPTION
This updates the section on how the release manager works to mention that a label is required. It also explicitly mentions that the Cloud Run service should be run on the user's own GCP project