### PR TITLE
rollout: Change message when candidate is not found

### DIFF
--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -118,13 +118,13 @@ func (r *Rollout) Rollout() (bool, error) {
 func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 	stable := DetectStableRevisionName(svc)
 	if stable == "" {
-		r.log.Info("could not determine stable revision")
+		r.log.Info("no stable revision found")
 		return nil, nil
 	}
 
 	candidate := DetectCandidateRevisionName(svc, stable)
 	if candidate == "" {
-		r.log.Info("could not determine candidate revision")
+		r.log.Debug("no candidate revision found")
 		return nil, nil
 	}
 	r.log = r.log.WithFields(logrus.Fields{"stable": stable, "candidate": candidate})

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -118,13 +118,13 @@ func (r *Rollout) Rollout() (bool, error) {
 func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, error) {
 	stable := DetectStableRevisionName(svc)
 	if stable == "" {
-		r.log.Info("no stable revision found")
+		r.log.Info("cannot find a stable revision (that gets 100% of the traffic)")
 		return nil, nil
 	}
 
 	candidate := DetectCandidateRevisionName(svc, stable)
 	if candidate == "" {
-		r.log.Debug("no candidate revision found")
+		r.log.Debug("currently no candidate revision exists to rollout")
 		return nil, nil
 	}
 	r.log = r.log.WithFields(logrus.Fields{"stable": stable, "candidate": candidate})


### PR DESCRIPTION
This updates the log messages when no stable or candidate revision is found. It also changes the type of log to debug in the case of no candidate since it occurs often