### PR TITLE
rollout: Report health for all cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ most relevant values are:
   Manager will get metrics about the candidate revision from the last 30 minutes
 - `-min-requests=0`: The Release Manager expects this number of requests in the
   past 30 minutes (given by `healthcheck-offset`). If no enough requests were
-  made in that interval, no rollout or rollback is performed even if the other
-  metrics show a healthy/unhealthy candidate. The default value of `0` means
-  that the number of requests should be ignored when the Release Manager makes
-  a decission about rolling out/back.
+  made in that interval, no rollout is performed even if the other metrics show
+  a healthy candidate. The default value of `0` means that the number of
+  requests should be ignored when the Release Manager makes a decision about
+  rolling out the candidate.
 - `-max-error-rate=1` (in percent): By default, the only health criteria is a
   expected max server error rate of 1%
 - `-min-wait=30m`: If the candidate revision is healthy, it can be rolled out

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -253,8 +253,8 @@ func flagsToString() string {
 // of config.Metric based on them.
 func healthCriteriaFromFlags(requestCount int, errorRate, latencyP99, latencyP95, latencyP50 float64) []config.HealthCriterion {
 	metrics := []config.HealthCriterion{
-		{Metric: config.ErrorRateMetricsCheck, Threshold: errorRate},
 		{Metric: config.RequestCountMetricsCheck, Threshold: float64(requestCount)},
+		{Metric: config.ErrorRateMetricsCheck, Threshold: errorRate},
 	}
 
 	if latencyP99 > 0 {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -82,16 +82,20 @@ func Diagnose(ctx context.Context, healthCriteria []config.HealthCriterion, actu
 		}
 
 		isMet := isCriteriaMet(criteria.Metric, criteria.Threshold, value)
+		result := CheckResult{Threshold: criteria.Threshold, ActualValue: value}
 
 		// For unmet request count, return inconclusive and empty results.
 		if !isMet && criteria.Metric == config.RequestCountMetricsCheck {
 			logger.Debug("unmet criterion")
 			diagnosis = Inconclusive
-			results = nil
+			// TODO: This will be an issue if the request count is not the first
+			// criterion in the array since the caller can assume the order
+			// of the check results is the same as the order of the health
+			// criteria.
+			results = []CheckResult{result}
 			break
 		}
 
-		result := CheckResult{Threshold: criteria.Threshold, ActualValue: value}
 		if !isMet {
 			logger.Debug("unmet criterion")
 			diagnosis = Unhealthy

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -54,11 +54,15 @@ type CheckResult struct {
 // actual values are not the same, the diagnosis is Unknown and an error is
 // returned.
 //
-// If the minimum number of requests is not met, then health cannot be
-// determined and diagnosis is Inconclusive.
+// Otherwise, all metrics criteria are checked to determine the diagnosis:
+// healthy, unhealthy, or inconclusive.
 //
-// Otherwise, all metrics criteria are checked to determine whether the revision
-// is healthy or not.
+// If the minimum number of requests is not met, the diagnosis is Inconclusive
+// even though all other criteria are met.
+//
+// However, if any criteria other than the request count is not met, the
+// diagnosis is unhealthy independent on the request count criteria. That is,
+// Unhealthy has precedence over Inconclusive.
 func Diagnose(ctx context.Context, healthCriteria []config.HealthCriterion, actualValues []float64) (Diagnosis, error) {
 	logger := util.LoggerFrom(ctx)
 	if len(healthCriteria) != len(actualValues) {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -54,13 +54,14 @@ func TestDiagnosis(t *testing.T) {
 			name: "no enough requests, inconclusive",
 			healthCriteria: []config.HealthCriterion{
 				{Metric: config.RequestCountMetricsCheck, Threshold: 1000},
-				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 500},
+				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 1000},
 			},
 			results: []float64{800, 750.0},
 			expected: health.Diagnosis{
 				OverallResult: health.Inconclusive,
 				CheckResults: []health.CheckResult{
 					{Threshold: 1000, ActualValue: 800, IsCriteriaMet: false},
+					{Threshold: 1000, ActualValue: 750.0, IsCriteriaMet: true},
 				},
 			},
 		},
@@ -100,6 +101,21 @@ func TestDiagnosis(t *testing.T) {
 				OverallResult: health.Unhealthy,
 				CheckResults: []health.CheckResult{
 					{Threshold: 0.95, ActualValue: 1.0},
+				},
+			},
+		},
+		{
+			name: "unhealthy revision with request count not reaching min",
+			healthCriteria: []config.HealthCriterion{
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 0.95},
+				{Metric: config.RequestCountMetricsCheck, Threshold: 1000},
+			},
+			results: []float64{1.0, 500},
+			expected: health.Diagnosis{
+				OverallResult: health.Unhealthy,
+				CheckResults: []health.CheckResult{
+					{Threshold: 0.95, ActualValue: 1.0, IsCriteriaMet: false},
+					{Threshold: 1000, ActualValue: 500, IsCriteriaMet: false},
 				},
 			},
 		},

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -59,7 +59,9 @@ func TestDiagnosis(t *testing.T) {
 			results: []float64{800, 750.0},
 			expected: health.Diagnosis{
 				OverallResult: health.Inconclusive,
-				CheckResults:  nil,
+				CheckResults: []health.CheckResult{
+					{Threshold: 1000, ActualValue: 800, IsCriteriaMet: false},
+				},
 			},
 		},
 		{

--- a/internal/health/report.go
+++ b/internal/health/report.go
@@ -7,9 +7,15 @@ import (
 )
 
 // StringReport returns a human-readable report of the diagnosis.
-func StringReport(healthCriteria []config.HealthCriterion, diagnosis Diagnosis) string {
-	report := fmt.Sprintf("status: %s\n", diagnosis.OverallResult.String())
-	report += "metrics:"
+func StringReport(healthCriteria []config.HealthCriterion, diagnosis Diagnosis, enoughTimeSinceLastRollout bool) string {
+	report := fmt.Sprintf("status: %s", diagnosis.OverallResult.String())
+
+	// If no enough time has passed, add the information in the status.
+	if diagnosis.OverallResult == Healthy && !enoughTimeSinceLastRollout {
+		report += ", but no enough time since last rollout"
+	}
+
+	report += "\nmetrics:"
 	for i, result := range diagnosis.CheckResults {
 		criteria := healthCriteria[i]
 

--- a/internal/rollout/rollout_test.go
+++ b/internal/rollout/rollout_test.go
@@ -190,6 +190,16 @@ func TestUpdateService(t *testing.T) {
 				{Metric: config.LatencyMetricsCheck, Percentile: 99, Threshold: 750},
 				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
 			},
+			outAnnotations: map[string]string{
+				rollout.StableRevisionAnnotation:    "test-001",
+				rollout.CandidateRevisionAnnotation: "test-002",
+				rollout.LastRolloutAnnotation:       makeLastRolloutAnnotation(clockMock, 0),
+				rollout.LastHealthReportAnnotation: "status: healthy, but no enough time since last rollout\n" +
+					"metrics:" +
+					"\n- request-latency[p99]: 500.00 (needs 750.00)" +
+					"\n- error-rate-percent: 1.00 (needs 5.00)" +
+					fmt.Sprintf("\nlastUpdate: %s", clockMock.Now().Format(time.RFC3339)),
+			},
 			changedTraffic: false,
 		},
 		{
@@ -258,7 +268,6 @@ func TestUpdateService(t *testing.T) {
 				rollout.StableRevisionAnnotation:              "test-001",
 				rollout.CandidateRevisionAnnotation:           "test-002",
 				rollout.LastFailedCandidateRevisionAnnotation: "test-002",
-				rollout.LastRolloutAnnotation:                 makeLastRolloutAnnotation(clockMock, 0),
 				rollout.LastHealthReportAnnotation: "status: unhealthy\n" +
 					"metrics:" +
 					"\n- request-latency[p99]: 500.00 (needs 100.00)" +
@@ -281,7 +290,10 @@ func TestUpdateService(t *testing.T) {
 				{RevisionName: "test-001", Percent: 100},
 				{LatestRevision: true, Tag: rollout.LatestTag},
 			},
-			lastReady:      "test-002",
+			lastReady: "test-002",
+			outAnnotations: map[string]string{
+				rollout.LastFailedCandidateRevisionAnnotation: "test-002",
+			},
 			changedTraffic: false,
 		},
 		{
@@ -293,7 +305,15 @@ func TestUpdateService(t *testing.T) {
 			lastReady: "test-002",
 			healthCriteria: []config.HealthCriterion{
 				{Metric: config.RequestCountMetricsCheck, Threshold: 1500},
-				{Metric: config.ErrorRateMetricsCheck, Threshold: 0.95},
+				{Metric: config.ErrorRateMetricsCheck, Threshold: 5},
+			},
+			outAnnotations: map[string]string{
+				rollout.StableRevisionAnnotation:    "test-001",
+				rollout.CandidateRevisionAnnotation: "test-002",
+				rollout.LastHealthReportAnnotation: "status: inconclusive\n" +
+					"metrics:" +
+					"\n- request-count: 1000 (needs 1500)" +
+					fmt.Sprintf("\nlastUpdate: %s", clockMock.Now().Format(time.RFC3339)),
 			},
 			changedTraffic: false,
 		},
@@ -331,14 +351,18 @@ func TestUpdateService(t *testing.T) {
 		r := rollout.New(context.TODO(), metricsMock, svcRecord, strategy).WithClient(runclient).WithLogger(lg).WithClock(clockMock)
 
 		t.Run(test.name, func(tt *testing.T) {
-			svc, changedTraffic, err := r.UpdateService(svc)
+			retSvc, changedTraffic, err := r.UpdateService(svc)
 			if test.shouldErr {
 				assert.NotNil(tt, err)
-			} else if !test.changedTraffic {
-				assert.False(tt, changedTraffic)
+				return
+			}
+
+			assert.Equal(tt, test.changedTraffic, changedTraffic)
+			assert.Equal(tt, test.outAnnotations, retSvc.Metadata.Annotations)
+			if !test.changedTraffic {
+				assert.Equal(tt, svc.Spec.Traffic, retSvc.Spec.Traffic)
 			} else {
-				assert.Equal(tt, test.outAnnotations, svc.Metadata.Annotations)
-				assert.Equal(tt, test.outTraffic, svc.Spec.Traffic)
+				assert.Equal(tt, test.outTraffic, retSvc.Spec.Traffic)
 			}
 		})
 

--- a/internal/rollout/rollout_test.go
+++ b/internal/rollout/rollout_test.go
@@ -313,6 +313,7 @@ func TestUpdateService(t *testing.T) {
 				rollout.LastHealthReportAnnotation: "status: inconclusive\n" +
 					"metrics:" +
 					"\n- request-count: 1000 (needs 1500)" +
+					"\n- error-rate-percent: 1.00 (needs 5.00)" +
 					fmt.Sprintf("\nlastUpdate: %s", clockMock.Now().Format(time.RFC3339)),
 			},
 			changedTraffic: false,

--- a/internal/rollout/traffic.go
+++ b/internal/rollout/traffic.go
@@ -28,6 +28,7 @@ func (r *Rollout) determineTraffic(svc *run.Service, diagnosis health.DiagnosisR
 			return svc.Spec.Traffic, false, nil
 		}
 		r.log.Info("rolling forward")
+		r.shouldRollout = true
 		return r.rollForwardTraffic(svc.Spec.Traffic, stable, candidate), true, nil
 	case health.Unhealthy:
 		r.log.Info("unhealthy candidate, rollback")


### PR DESCRIPTION
This reports the health for all possible cases. In particular, it reports inconclusive diagnosis (no enough requests) and healthy diagnosis without enough elapsed time.