### PR TITLE
rollout: Publish rollout events to PubSub

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -171,7 +171,6 @@ func main() {
 		if err != nil {
 			logger.Fatalf("failed to initialize Pub/Sub client: %v", err)
 		}
-
 	}
 
 	if flCLI {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -166,6 +166,7 @@ func main() {
 	ctx := context.Background()
 	var pubsub ps.Client
 	if flPubSubTopic != "" {
+		logger.WithField("topic", flPubSubTopic).Debug("will publish to Pub/Sub")
 		ctx = util.ContextWithLogger(ctx, logrus.NewEntry(logger))
 		pubsub, err = ps.New(ctx, flProject, flPubSubTopic)
 		if err != nil {

--- a/cmd/operator/server.go
+++ b/cmd/operator/server.go
@@ -5,15 +5,16 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/cloud-run-release-manager/internal/config"
+	ps "github.com/GoogleCloudPlatform/cloud-run-release-manager/internal/notification/pubsub"
 	"github.com/sirupsen/logrus"
 )
 
 // makeRolloutHandler creates a request handler to perform a rollout process.
-func makeRolloutHandler(logger *logrus.Logger, cfg *config.Config) http.HandlerFunc {
+func makeRolloutHandler(logger *logrus.Logger, cfg *config.Config, pubsub ps.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		// TODO(gvso): Handle all the strategies.
-		errs := runRollouts(ctx, logger, cfg.Strategies[0])
+		errs := runRollouts(ctx, logger, cfg.Strategies[0], pubsub)
 		errsStr := rolloutErrsToString(errs)
 		if len(errs) != 0 {
 			msg := fmt.Sprintf("there were %d errors: \n%s", len(errs), errsStr)

--- a/internal/notification/pubsub/pubsub.go
+++ b/internal/notification/pubsub/pubsub.go
@@ -23,6 +23,7 @@ const (
 // Client represents a client to Google Cloud Pub/Sub.
 type Client interface {
 	Publish(ctx context.Context, event RolloutEvent) error
+	Stop()
 }
 
 // PubSub is a Google Cloud Pub/Sub client to publish messages.

--- a/internal/notification/pubsub/pubsub.go
+++ b/internal/notification/pubsub/pubsub.go
@@ -23,7 +23,6 @@ const (
 // Client represents a client to Google Cloud Pub/Sub.
 type Client interface {
 	Publish(ctx context.Context, event RolloutEvent) error
-	Stop()
 }
 
 // PubSub is a Google Cloud Pub/Sub client to publish messages.
@@ -101,20 +100,17 @@ func (ps PubSub) Publish(ctx context.Context, event RolloutEvent) error {
 	}
 
 	logger := util.LoggerFrom(ctx)
-	ps.topic.Publish(ctx, &cloudpubsub.Message{
-		Data: data,
-	})
-	logger.WithField("size", len(data)).Debug("event published to Pub/Sub")
-	return nil
-}
+	result := ps.topic.Publish(ctx, &cloudpubsub.Message{Data: data})
+	serverID, err := result.Get(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to publish event to Pub/Sub")
+	}
 
-// Stop is a wrapper around Cloud Run Pub/Sub package's Stop method on Topic.
-//
-// It sends all remaining published messages and stop goroutines created for
-// handling publishing. Returns once all outstanding messages have been sent or
-// have failed to be sent.
-func (ps PubSub) Stop() {
-	ps.topic.Stop()
+	logger.WithFields(logrus.Fields{
+		"size":     len(data),
+		"serverID": serverID,
+	}).Debug("event published to Pub/Sub")
+	return nil
 }
 
 // findRevisionWithTag scans the service's traffic configuration and returns the

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -187,7 +187,7 @@ func (r *Rollout) replaceServiceAndPublish(svc *run.Service, trafficChanged bool
 	svc, err := r.runClient.ReplaceService(r.project, r.serviceName, svc)
 
 	if trafficChanged {
-		pubErr := r.publish(svc, diagnosis)
+		pubErr := r.publishEvent(svc, diagnosis)
 		if pubErr != nil {
 			r.log.Warnf("failed to publish rollout/rollback message: %v", pubErr)
 		}
@@ -249,7 +249,7 @@ func (r *Rollout) diagnoseCandidate(candidate string, healthCriteria []config.He
 	return d, errors.Wrap(err, "failed to diagnose candidate's health")
 }
 
-func (r *Rollout) publish(svc *run.Service, diagnosis health.DiagnosisResult) error {
+func (r *Rollout) publishEvent(svc *run.Service, diagnosis health.DiagnosisResult) error {
 	if r.pubsubClient == nil {
 		return nil
 	}
@@ -263,8 +263,5 @@ func (r *Rollout) publish(svc *run.Service, diagnosis health.DiagnosisResult) er
 	if err != nil {
 		return errors.Wrap(err, "error when publishing message")
 	}
-
-	// Wait for all messages to be sent (or to fail).
-	r.pubsubClient.Stop()
 	return nil
 }

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -256,12 +256,12 @@ func (r *Rollout) publishEvent(svc *run.Service, diagnosis health.DiagnosisResul
 
 	event, err := pubsub.NewRolloutEvent(svc, diagnosis, r.promoteToStable)
 	if err != nil {
-		return errors.Wrap(err, "failed to create message")
+		return errors.Wrap(err, "failed to create rollout event message")
 	}
 	ctx := util.ContextWithLogger(r.ctx, r.log)
 	err = r.pubsubClient.Publish(ctx, event)
 	if err != nil {
-		return errors.Wrap(err, "error when publishing message")
+		return errors.Wrap(err, "error when publishing rollout event")
 	}
 	return nil
 }

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -178,7 +178,7 @@ func (r *Rollout) UpdateService(svc *run.Service) (*run.Service, bool, error) {
 	r.setHealthReportAnnotation(svc, report)
 
 	err = r.replaceServiceAndPublish(svc, trafficChanged, diagnosis.OverallResult)
-	return svc, true, errors.Wrap(err, "failed to replace service")
+	return svc, trafficChanged, errors.Wrap(err, "failed to replace service")
 }
 
 // replaceServiceAndPublish updates the service object in Cloud Run. Then, it


### PR DESCRIPTION
This integrates the rollout package with the pubsub package to publish events after rollouts/rollbacks occur. It also adds a new flag `--notify-pubsub` to specify the PubSub topic.